### PR TITLE
Alias parsing and expansion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Ben Holt
+Copyright (c) 2019-2020 Ben Holt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sled
+++ b/sled
@@ -124,7 +124,6 @@ def main(args, env, stdin):
         print(style_helper())
         return 0
 
-
     named_lines = []
     add_lines = []
     if my_args.rules_file:
@@ -147,11 +146,6 @@ def main(args, env, stdin):
 
     if my_args.default_rule:
         rules.append(my_args.default_rule)
-
-    rules = [ 
-        [ f if f is None or not f.startswith("$$") else f[1:] for f in r ] 
-        for r in rules 
-        ]
 
     if my_args.print_args:
         n_str = "\n\t".join(f"{n}: {r}" for n,r in named_rules.items())
@@ -186,18 +180,10 @@ def parse_aliases(l, existing=None, override=False):
 
     for s in l:
         name,*fields = split_rule(s)
-        assert not name.startswith("$"), f"Rule name '{name}' cannot start with $"
-
-        name = f"${name}"  # All the lookups are way easier if we just work with the $-prefix
         if not override and name in existing:
             continue
 
         fields = resolve_aliases(fields, aliases, existing)
-
-        # if [ f for f in fields if f is not None and f.startswith("$") and not f.startswith("$$") ]:
-        #     # Stash any aliases that did not completely resolve
-        #     unresolved[name] = fields
-        #     continue
 
         aliases[name] = fields
 
@@ -224,9 +210,9 @@ def parse_rules(l, aliases=None):
         if len(parts) < 2:  # ensure at least 2 fields
             parts = [*parts, None, None][:2]
         tag = None
-        if (len(parts) == 2 and parts[0] is not None and parts[0].startswith("$")):
+        if (len(parts) == 2 and parts[0] is not None and parts[0] in aliases):
             # get auto-tag for pure-alias rule
-            tag = parts[0].lstrip("$")
+            tag = parts[0]
             if parts[1] is not None:
                 tag = parts[1]
                 parts[1] = None  # drop the explicit tag for now

--- a/sled
+++ b/sled
@@ -69,13 +69,6 @@ def main(args, env, stdin):
         metavar="RULE",
         help="Add rules to the statemachine.",
     )
-    # arg_parser.add_argument(
-    #     "-c", "--strip-comments",
-    #     action="store_true",
-    #     # const=(None, sm.true_test, None, None, "StripComments"),
-    #     # default=None,
-    #     help="Add a StripComments rule to scrub #-style comments; must be explicitly added to states to raise its priority."
-    # )
     arg_parser.add_argument(
         "-d", "--drop-all",
         dest="default_rule",
@@ -129,10 +122,6 @@ def main(args, env, stdin):
     add_lines = []
     if my_args.rules_file:
         (named_lines, add_lines) = rules_from_file(my_args.rules_file)
-
-    # if my_args.strip_comments:
-    #     named_rules["$StripComments"] = (sm.true_test, None, strip_comments_action, None)
-    #     add_lines.append("::StripComments")
 
     # First parse command-line to lay down any low-level aliases
     named_rules = parse_aliases(my_args.named_rules)

--- a/sled
+++ b/sled
@@ -80,7 +80,7 @@ def main(args, env, stdin):
         "-d", "--drop-all",
         dest="default_rule",
         action="store_const",
-        const=(None, sm.true_test, None, None, "DropAll"),
+        const=(None, "T", None, None, None, None, "DropAll"),
         default=None,
         help="Add a final DropAll rule to drop any input not handled."
     )
@@ -88,7 +88,7 @@ def main(args, env, stdin):
         "-p", "--pass-all",
         dest="default_rule",
         action="store_const",
-        const=(None, sm.true_test, None, sm.input_action, "PassAll"),
+        const=(None, "T", None, None, "I", None, "PassAll"),
         default=None,
         help="Add a final PassAll rule to pass any input not handled."
     )
@@ -153,7 +153,9 @@ def main(args, env, stdin):
         rules.append(my_args.default_rule)
 
     if my_args.print_args:
-        print(f"* Args:\n\t{my_args}\n* Named Rules:\n\t{named_rules}\n* Rules:\n\t{rules}")
+        n_str = "\n\t".join(f"{n}: {r}" for n,r in named_rules.items())
+        r_str = "\n\t".join(f"{s}: {r}" for s,*r in rules)
+        print(f"* Args:\n\t{my_args}\n* Named Rules:\n\t{n_str}\n* Rules:\n\t{r_str}")
         return 0
     if my_args.more_help:
         print(wrapper(f"{helper(Tests)}\n\n{helper(Actions)}", width=75))
@@ -173,7 +175,8 @@ def main(args, env, stdin):
             tracer = sm.Tracer(printer=my_args.trace)
     parser = sm.StateMachine(my_args.start, tracer=tracer)
     for r in rules:
-        parser.add(*r)
+        # print(r)
+        parser.add(*resolve_rule(*r))
 
     for line in parser.parse( l.rstrip("\n") for l in stdin ):
         print(line)
@@ -239,7 +242,7 @@ def parse_rules(l, aliases=None):
         if tag is not None:
             parts[-1] = tag  # apply saved tag
 
-        rules.append(resolve_rule(state, *parts))
+        rules.append((state, *parts))
 
     return rules
 

--- a/sled
+++ b/sled
@@ -21,18 +21,26 @@ import statemachine as sm
 
 ###  Main  ###
 def main(args, env, stdin):
-    description = "Statemachine Line EDitor, like `sed` but built with statemachine rules (v1.0)"
+    description = "Statemachine Line EDitor, like `sed` but built with statemachine rules (v1.5)"
     epilog = textwrap.dedent("""\
-    Rules can be created with -r/--named-rules and start with a delimiter character of our choice follwed by 7 fields:
+    Rules can be created with -r/--named-rules and start with a delimiter character of our choice follwed by up to 7 fields:
 
         :name:test:arg:dst:action:arg:tag
 
-    Rules are added to states in the underlying statemachine with -a/--add-rules, and may be either named or anonymous:
+    Named rules can use previously defined named rule fragments; for example, a complex regular expression can be defined once and used elsewhere:
 
-        :state:name:tag
+        :CommentRE:(^|\s+)#($|[^#].*$)
+        :DropComments:S:CommentRE::S::
+
+    Rules are added to states in the underlying statemachine with -a/--add-rules:
+
         :state:test:arg:dst:action:arg:tag
 
     Unnecessary fields may be omitted from the end in all cases, and 'test' and 'action' commands are not case-sensitive.  Rules with no 'state' specified are implicitly added to all states, but evaluated after any explicit rules; rules with no 'dst' remain in the same state ("self-transition")
+
+    Rules can use previously defined rule fragments; if the rule is completely defined by a named rule, like the following, it will be auto-tagged with that name:
+
+        :state:name
 
     More documentation and examples in sled.md:
     https://github.com/inventhouse/statemachine/blob/master/sled.md
@@ -109,10 +117,16 @@ def main(args, env, stdin):
         help="Print help about the available text styles.",
     )
     arg_parser.add_argument(
+        "--print-rules",
+        action="store_true",
+        help="Print the parsed rules, then exit.  Named rules do not get automatically added to the parser; the 'Rules' list are the ones that define the parser.  They are added to their states in order, and earlier rules have precedence over later ones.",
+        # help=argparse.SUPPRESS,
+    )
+    arg_parser.add_argument(
         "--print-args",
         action="store_true",
-        help="Print arguments and parsed rules, then exit.",
-        # help=argparse.SUPPRESS,
+        # help="Print arguments and parsed rules, then exit.",
+        help=argparse.SUPPRESS,
     )
     my_args = arg_parser.parse_args(args[1:])
 
@@ -147,10 +161,12 @@ def main(args, env, stdin):
     if my_args.default_rule:
         rules.append(my_args.default_rule)
 
+    if my_args.print_rules:
+        print(format_rules(named_rules, rules))
+        return 0
+
     if my_args.print_args:
-        n_str = "\n\t".join(f"{n}: {r}" for n,r in named_rules.items())
-        r_str = "\n\t".join(f"{s}: {r}" for s,*r in rules)
-        print(f"* Args:\n\t{my_args}\n* Named Rules:\n\t{n_str}\n* Rules:\n\t{r_str}")
+        print(f"* Args:\n\t{my_args}\n\n{format_rules(named_rules, rules)}")
         return 0
 
     tracer = True  # Use the built-in default tracing
@@ -206,21 +222,18 @@ def parse_rules(l, aliases=None):
         aliases = {}
     rules = []
     for s in l:
+        autotag = None
         state,*parts = split_rule(s)
-        if len(parts) < 2:  # ensure at least 2 fields
-            parts = [*parts, None, None][:2]
-        tag = None
-        if (len(parts) == 2 and parts[0] is not None and parts[0] in aliases):
+        if len(parts) < 1:  # ensure at least 1 field
+            parts = [None,]
+        if (len(parts) == 1 and parts[0] is not None and parts[0] in aliases):
             # get auto-tag for pure-alias rule
-            tag = parts[0]
-            if parts[1] is not None:
-                tag = parts[1]
-                parts[1] = None  # drop the explicit tag for now
+            autotag = parts[0]
 
         parts = resolve_aliases(parts, aliases)
         parts = (parts + [None,] * 6)[:6]  # Expand parts to 6 fields
-        if tag is not None:
-            parts[-1] = tag  # apply saved tag
+        if autotag is not None:
+            parts[-1] = autotag  # apply saved tag
 
         rules.append((state, *parts))
 
@@ -323,6 +336,8 @@ class Actions:
     def s(s):
         ":S:r:\tSub all occurrences of the test pattern with a replacement; formatting is available in the replacement string as describe above."
         # TODO: assert the result is an re.match
+        if s is None:
+            s = ""
         return lambda i, t: t.result.re.sub(s.format(i=i, r=t.result, s=style), i)
 
     def _default(s):
@@ -427,6 +442,13 @@ def style_helper():
     cl = [ "{{s.{n}_bg}}{n}_bg{{s.off}}".format(n=n).format(s=style) for n in COLOR_NAMES]
     h.append("\t" + "  ".join(cl))
     return "\n".join(h)
+
+
+def format_rules(named_rules, rules):
+        n_str = "\n\t".join(f"{n}: {r}" for n,r in named_rules.items())
+        r_str = "\n\t".join(f"{s}: {r}" for s,*r in rules)
+        return f"* Named Rules:\n\t{n_str}\n\n* Rules:\n\t{r_str}"
+
 #####
 
 

--- a/sled
+++ b/sled
@@ -148,7 +148,10 @@ def main(args, env, stdin):
     if my_args.default_rule:
         rules.append(my_args.default_rule)
 
-    # named_rules, rules, unresolved = fix_prefixes(named_rules, rules)
+    rules = [ 
+        [ f if f is None or not f.startswith("$$") else f[1:] for f in r ] 
+        for r in rules 
+        ]
 
     if my_args.print_args:
         n_str = "\n\t".join(f"{n}: {r}" for n,r in named_rules.items())
@@ -237,9 +240,6 @@ def parse_rules(l, aliases=None):
 
     return rules
 
-
-# def fix_prefixes(aliases, rules):
-#     pass
 
 def resolve_rule(state, test, t_arg, dst, action, a_arg, tag):
     if not test:

--- a/sled
+++ b/sled
@@ -137,14 +137,15 @@ def main(args, env, stdin):
     # First parse command-line to lay down any low-level aliases
     named_rules = parse_aliases(my_args.named_rules)
 
-    # Then parse named rules from file
+    # Then parse aliases from file
     aliases = parse_aliases(named_lines, existing=named_rules, override = False)  # Don't override the command-line
     named_rules.update(aliases)
 
-    # Finally override any rules based on the command-line again
+    # Finally override any aliases based on the command-line again
     aliases = parse_aliases(my_args.named_rules, existing=named_rules, override = True)
     named_rules.update(aliases)
 
+    # Parse rules
     rules = parse_rules(my_args.add_rules, aliases=named_rules)  # Added rules in args have higher precedence than rules from the file
     rules.extend(parse_rules(add_lines, aliases=named_rules))
 

--- a/sled
+++ b/sled
@@ -111,13 +111,20 @@ def main(args, env, stdin):
     arg_parser.add_argument(
         "--print-args",
         action="store_true",
-        # help="Print arguments and compiled rules, then exit.",
-        help=argparse.SUPPRESS,
+        help="Print arguments and parsed rules, then exit.",
+        # help=argparse.SUPPRESS,
     )
     my_args = arg_parser.parse_args(args[1:])
 
-    # named_rules = {}
-    # rules = []
+    if my_args.more_help:
+        print(wrapper(f"{helper(Tests)}\n\n{helper(Actions)}", width=75))
+        return 0
+    if my_args.style_help:
+        print(wrapper("In formatting contexts, styles and colors are available as attributes on an object `s`, and usually output should returned to normal with `s.off`, though a couple styles also offer end-codes.  Like this:\n\n\tTo {{s.b}}boldly{{s.off}} go where no one has gone before\n\tTo {s.b}boldly{s.off} go where no one has gone before\n\nText styling varies a lot based on the terminal and settings, and is omitted if the output is redirected.  Here are some examples of their appearance:\n".format(s=style), width=75))
+        print(style_helper())
+        return 0
+
+
     named_lines = []
     add_lines = []
     if my_args.rules_file:
@@ -141,17 +148,12 @@ def main(args, env, stdin):
     if my_args.default_rule:
         rules.append(my_args.default_rule)
 
+    # named_rules, rules, unresolved = fix_prefixes(named_rules, rules)
+
     if my_args.print_args:
         n_str = "\n\t".join(f"{n}: {r}" for n,r in named_rules.items())
         r_str = "\n\t".join(f"{s}: {r}" for s,*r in rules)
         print(f"* Args:\n\t{my_args}\n* Named Rules:\n\t{n_str}\n* Rules:\n\t{r_str}")
-        return 0
-    if my_args.more_help:
-        print(wrapper(f"{helper(Tests)}\n\n{helper(Actions)}", width=75))
-        return 0
-    if my_args.style_help:
-        print(wrapper("In formatting contexts, styles and colors are available as attributes on an object `s`, and usually output should returned to normal with `s.off`, though a couple styles also offer end-codes.  Like this:\n\n\tTo {{s.b}}boldly{{s.off}} go where no one has gone before\n\tTo {s.b}boldly{s.off} go where no one has gone before\n\nText styling varies a lot based on the terminal and settings, and is omitted if the output is redirected.  Here are some examples of their appearance:\n".format(s=style), width=75))
-        print(style_helper())
         return 0
 
     tracer = True  # Use the built-in default tracing
@@ -204,10 +206,10 @@ def resolve_aliases(fields, *lookups):
         for l in lookups:
             if f in l:
                 return l[f]
-        return [f,]
+        return [f,]  # wrap in list to keep everything on the same level
 
-    expanded = ( expand(f) for f in fields )  # expansion produces list-of-lists
-    return [ f for e in expanded for f in e ]  #...then flatten back into a list
+    expanded = ( expand(f) for f in fields )  # expansion produces list-of-lists...
+    return [ f for e in expanded for f in e ]  #...so flatten back into a list
 
 
 def parse_rules(l, aliases=None):
@@ -235,6 +237,9 @@ def parse_rules(l, aliases=None):
 
     return rules
 
+
+# def fix_prefixes(aliases, rules):
+#     pass
 
 def resolve_rule(state, test, t_arg, dst, action, a_arg, tag):
     if not test:

--- a/sled
+++ b/sled
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019 Benjamin Holt -- MIT License
+# Copyright (c) 2019-2020 Benjamin Holt -- MIT License
 
 """
 Statemachine Line EDitor

--- a/sled
+++ b/sled
@@ -134,21 +134,16 @@ def main(args, env, stdin):
     #     named_rules["$StripComments"] = (sm.true_test, None, strip_comments_action, None)
     #     add_lines.append("::StripComments")
 
-    # named_rules.update({ n: r for n,*r in parse_rules(named_lines) })  # BJH: FIXME: these will become parse_aliases which will return the dicts
-    # named_rules.update({ n: r for n,*r in parse_rules(my_args.named_rules) })  # Named rules in args can override named rules from the file 
-
     # First parse command-line to lay down any low-level aliases
-    (named_rules, unresolved_rules) = parse_aliases(my_args.named_rules)
+    named_rules = parse_aliases(my_args.named_rules)
 
     # Then parse named rules from file
-    (aliases, unresolved) = parse_aliases(named_lines, existing=named_rules, override = False)  # Don't override the command-line
+    aliases = parse_aliases(named_lines, existing=named_rules, override = False)  # Don't override the command-line
     named_rules.update(aliases)
-    unresolved_rules.update(unresolved)
 
     # Finally override any rules based on the command-line again
-    (aliases, unresolved) = parse_aliases(my_args.named_rules, existing=named_rules, override = True)
+    aliases = parse_aliases(my_args.named_rules, existing=named_rules, override = True)
     named_rules.update(aliases)
-    unresolved_rules.update(unresolved)
 
     rules = parse_rules(my_args.add_rules, aliases=named_rules)  # Added rules in args have higher precedence than rules from the file
     rules.extend(parse_rules(add_lines, aliases=named_rules))
@@ -185,10 +180,12 @@ def main(args, env, stdin):
 
 
 ###  Rule Parsing  ###
-def parse_aliases(l, existing={}, override=False):
+def parse_aliases(l, existing=None, override=False):
     "Parse a list of named rule strings into aliases for add-rules"
+    if existing is None:
+        existing = {}  # {"$name": [fields...], ...}
     aliases = {}  # {"$name": [fields...], ...}
-    unresolved = {}  # {"$name": [fields...], ...}
+
     for s in l:
         name,*fields = split_rule(s)
         assert not name.startswith("$"), f"Rule name '{name}' cannot start with $"
@@ -197,42 +194,56 @@ def parse_aliases(l, existing={}, override=False):
         if not override and name in existing:
             continue
 
-        expanded = ( aliases.get(f) or existing.get(f, [f,]) for f in fields )  # try to expand each field into previously defined fields or "expand" into a list contining itself to keep everything on the same level...
-        fields = [ f for e in expanded for f in e ]  #...then flatten back into a list
+        fields = resolve_aliases(fields, aliases, existing)
 
-        if [ f for f in fields if f is not None and f.startswith("$") and not f.startswith("$$") ]:
-            # Stash any aliases that did not completely resolve
-            unresolved[name] = fields
-            continue
+        # if [ f for f in fields if f is not None and f.startswith("$") and not f.startswith("$$") ]:
+        #     # Stash any aliases that did not completely resolve
+        #     unresolved[name] = fields
+        #     continue
 
         aliases[name] = fields
 
-    return (aliases, unresolved)
+    return aliases
 
 
-def parse_rules(l, aliases={}):
+def resolve_aliases(fields, *lookups):
+    def expand(f):
+        for l in lookups:
+            if f in l:
+                return l[f]
+        return [f,]
+
+    expanded = ( expand(f) for f in fields )  # expansion produces list-of-lists
+    return [ f for e in expanded for f in e ]  #...then flatten back into a list
+
+
+def parse_rules(l, aliases=None):
+    if aliases is None:
+        aliases = {}
     rules = []
     for s in l:
-        parts = split_rule(s)
-        if (1 < len(parts) <= 3
-            and parts[1] is not None
-            and parts[1].startswith("$")):
-            # Expand and auto-tag pure-alias rule
-            name = parts[1]
-            assert name in aliases, f"Unresolved alias {name}"
-            tag = name.lstrip("$")
-            if len(parts) == 3 and parts[2] is not None:
-                tag = parts[2]
-            r = ([parts[0], *aliases[name]] + [None,] * 7)[:7]
-            r[-1] = tag
-        else:
-            # Expand literal rule to 7 fields
-            r = (parts + [None,] * 7)[:7]
-        rules.append(resolve_rule(*r))
+        state,*parts = split_rule(s)
+        if len(parts) < 2:  # ensure at least 2 fields
+            parts = [*parts, None, None][:2]
+        tag = None
+        if (len(parts) == 2 and parts[0] is not None and parts[0].startswith("$")):
+            # get auto-tag for pure-alias rule
+            tag = parts[0].lstrip("$")
+            if parts[1] is not None:
+                tag = parts[1]
+                parts[1] = None  # drop the explicit tag for now
+
+        parts = resolve_aliases(parts, aliases)
+        parts = (parts + [None,] * 6)[:6]  # Expand parts to 6 fields
+        if tag is not None:
+            parts[-1] = tag  # apply saved tag
+
+        rules.append(resolve_rule(state, *parts))
+
     return rules
 
 
-def resolve_rule(name, test, t_arg, dst, action, a_arg, tag):
+def resolve_rule(state, test, t_arg, dst, action, a_arg, tag):
     if not test:
         test = "_default"
     l_test = test.lower()
@@ -247,7 +258,7 @@ def resolve_rule(name, test, t_arg, dst, action, a_arg, tag):
         raise KeyError(f"no '{action}' in Actions, run with --more-help for full list")
     action = Actions.__dict__[l_action](a_arg)
 
-    return (name, test, dst, action, tag)
+    return (state, test, dst, action, tag)
 
 
 def split_rule(s):

--- a/sled
+++ b/sled
@@ -176,7 +176,6 @@ def main(args, env, stdin):
             # Add additional verbose tracing
             tracer = sm.Tracer(printer=my_args.trace)
     parser = sm.StateMachine(my_args.start, tracer=tracer)
-    # print([ r for r in rules if len(r) > 5 ])  # BJH: debug
     for r in rules:
         parser.add(*r)
 
@@ -196,7 +195,6 @@ def parse_aliases(l, existing={}, override=False):
 
         name = f"${name}"  # All the lookups are way easier if we just work with the $-prefix
         if not override and name in existing:
-            # print("don't override")
             continue
 
         expanded = ( aliases.get(f) or existing.get(f, [f,]) for f in fields )  # try to expand each field into previously defined fields or "expand" into a list contining itself to keep everything on the same level...
@@ -211,18 +209,6 @@ def parse_aliases(l, existing={}, override=False):
 
     return (aliases, unresolved)
 
-
-# def expand_alias(parts, aliases):
-#     parts += [None,] * 3
-#     expansion = aliases.get(parts[1], None)
-#     if expansion is not None:
-#         r = ([parts[0], *expansion] + [None,] * 7)[:7]
-#         if parts[2]:
-#             # Override the tag if one was specified
-#             r[-1] = parts[2]
-#         elif not r[-1]:
-#             # Auto-tag with rule name if none was specified
-#             r[-1] = parts[1]
 
 def parse_rules(l, aliases={}):
     rules = []
@@ -262,48 +248,6 @@ def resolve_rule(name, test, t_arg, dst, action, a_arg, tag):
     action = Actions.__dict__[l_action](a_arg)
 
     return (name, test, dst, action, tag)
-
-
-def x_parse_rules(l, aliases=None):
-    "Parse a list of rule strings into rules suitable for statemachine.add"
-    rules = []
-    for s in l:
-        parts = split_rule(s)
-
-        if aliases and len(parts) <= 3:  # FIXME: require $-prefix for alias lookups, give better error if unresolved
-            # Very short rule may be an alias reference
-            parts += [None,] * 3
-            expansion = aliases.get(parts[1], None)
-            if expansion is not None:
-                r = [parts[0], *expansion]
-                if parts[2]:
-                    # Override the tag if one was specified
-                    r[-1] = parts[2]
-                elif not r[-1]:
-                    # Auto-tag with rule name if none was specified
-                    r[-1] = parts[1]
-                rules.append(r)
-                continue
-
-        parts += [None,] * 7
-        (name, test, t_arg, dst, action, a_arg, tag) = parts[:7]
-
-        if not test:
-            test = "_default"
-        l_test = test.lower()
-        if l_test not in Tests.__dict__:
-            raise KeyError(f"no '{test}' in Tests, run with --more-help for full list")
-        test = Tests.__dict__[l_test](t_arg)
-
-        if not action:
-            action = "_default"
-        l_action = action.lower()
-        if l_action not in Actions.__dict__:
-            raise KeyError(f"no '{action}' in Actions, run with --more-help for full list")
-        action = Actions.__dict__[l_action](a_arg)
-
-        rules.append((name, test, dst, action, tag))
-    return rules
 
 
 def split_rule(s):
@@ -461,7 +405,6 @@ def rules_from_file(rules_file):
         # lines = list(lines); print("\n".join(lines), end="")  # join "spends" the generator, convert to list first so it can be iterated again
         for l in lines:
             categorizer.input(l)
-    # print(f"Named: {named_lines}\nAdd:{add_lines}")  # BJH: debug
     return (named_lines, add_lines)
 
 

--- a/sled
+++ b/sled
@@ -69,13 +69,13 @@ def main(args, env, stdin):
         metavar="RULE",
         help="Add rules to the statemachine.",
     )
-    arg_parser.add_argument(
-        "-c", "--strip-comments",
-        action="store_true",
-        # const=(None, sm.true_test, None, None, "StripComments"),
-        # default=None,
-        help="Add a StripComments rule to scrub #-style comments; must be explicitly added to states to raise its priority."
-    )
+    # arg_parser.add_argument(
+    #     "-c", "--strip-comments",
+    #     action="store_true",
+    #     # const=(None, sm.true_test, None, None, "StripComments"),
+    #     # default=None,
+    #     help="Add a StripComments rule to scrub #-style comments; must be explicitly added to states to raise its priority."
+    # )
     arg_parser.add_argument(
         "-d", "--drop-all",
         dest="default_rule",
@@ -123,20 +123,34 @@ def main(args, env, stdin):
     )
     my_args = arg_parser.parse_args(args[1:])
 
-    named_rules = {}
-    rules = []
+    # named_rules = {}
+    # rules = []
     named_lines = []
     add_lines = []
     if my_args.rules_file:
         (named_lines, add_lines) = rules_from_file(my_args.rules_file)
 
-    if my_args.strip_comments:
-        named_rules["StripComments"] = (sm.true_test, None, strip_comments_action, None)
-        add_lines.append("::StripComments")
+    # if my_args.strip_comments:
+    #     named_rules["$StripComments"] = (sm.true_test, None, strip_comments_action, None)
+    #     add_lines.append("::StripComments")
 
-    named_rules.update({ n: r for n,*r in parse_rules(named_lines) })
-    named_rules.update({ n: r for n,*r in parse_rules(my_args.named_rules) })  # Named rules in args can override named rules from the file
-    rules.extend(parse_rules(my_args.add_rules, aliases=named_rules))  # Added rules in args have higher precedence than rules from the file
+    # named_rules.update({ n: r for n,*r in parse_rules(named_lines) })  # BJH: FIXME: these will become parse_aliases which will return the dicts
+    # named_rules.update({ n: r for n,*r in parse_rules(my_args.named_rules) })  # Named rules in args can override named rules from the file 
+
+    # First parse command-line to lay down any low-level aliases
+    (named_rules, unresolved_rules) = parse_aliases(my_args.named_rules)
+
+    # Then parse named rules from file
+    (aliases, unresolved) = parse_aliases(named_lines, existing=named_rules, override = False)  # Don't override the command-line
+    named_rules.update(aliases)
+    unresolved_rules.update(unresolved)
+
+    # Finally override any rules based on the command-line again
+    (aliases, unresolved) = parse_aliases(my_args.named_rules, existing=named_rules, override = True)
+    named_rules.update(aliases)
+    unresolved_rules.update(unresolved)
+
+    rules = parse_rules(my_args.add_rules, aliases=named_rules)  # Added rules in args have higher precedence than rules from the file
     rules.extend(parse_rules(add_lines, aliases=named_rules))
 
     if my_args.default_rule:
@@ -162,6 +176,7 @@ def main(args, env, stdin):
             # Add additional verbose tracing
             tracer = sm.Tracer(printer=my_args.trace)
     parser = sm.StateMachine(my_args.start, tracer=tracer)
+    # print([ r for r in rules if len(r) > 5 ])  # BJH: debug
     for r in rules:
         parser.add(*r)
 
@@ -171,17 +186,96 @@ def main(args, env, stdin):
 
 
 ###  Rule Parsing  ###
-def parse_rules(l, aliases=None):
+def parse_aliases(l, existing={}, override=False):
+    "Parse a list of named rule strings into aliases for add-rules"
+    aliases = {}  # {"$name": [fields...], ...}
+    unresolved = {}  # {"$name": [fields...], ...}
+    for s in l:
+        name,*fields = split_rule(s)
+        assert not name.startswith("$"), f"Rule name '{name}' cannot start with $"
+
+        name = f"${name}"  # All the lookups are way easier if we just work with the $-prefix
+        if not override and name in existing:
+            # print("don't override")
+            continue
+
+        expanded = ( aliases.get(f) or existing.get(f, [f,]) for f in fields )  # try to expand each field into previously defined fields or "expand" into a list contining itself to keep everything on the same level...
+        fields = [ f for e in expanded for f in e ]  #...then flatten back into a list
+
+        if [ f for f in fields if f is not None and f.startswith("$") and not f.startswith("$$") ]:
+            # Stash any aliases that did not completely resolve
+            unresolved[name] = fields
+            continue
+
+        aliases[name] = fields
+
+    return (aliases, unresolved)
+
+
+# def expand_alias(parts, aliases):
+#     parts += [None,] * 3
+#     expansion = aliases.get(parts[1], None)
+#     if expansion is not None:
+#         r = ([parts[0], *expansion] + [None,] * 7)[:7]
+#         if parts[2]:
+#             # Override the tag if one was specified
+#             r[-1] = parts[2]
+#         elif not r[-1]:
+#             # Auto-tag with rule name if none was specified
+#             r[-1] = parts[1]
+
+def parse_rules(l, aliases={}):
+    rules = []
+    for s in l:
+        parts = split_rule(s)
+        if (1 < len(parts) <= 3
+            and parts[1] is not None
+            and parts[1].startswith("$")):
+            # Expand and auto-tag pure-alias rule
+            name = parts[1]
+            assert name in aliases, f"Unresolved alias {name}"
+            tag = name.lstrip("$")
+            if len(parts) == 3 and parts[2] is not None:
+                tag = parts[2]
+            r = ([parts[0], *aliases[name]] + [None,] * 7)[:7]
+            r[-1] = tag
+        else:
+            # Expand literal rule to 7 fields
+            r = (parts + [None,] * 7)[:7]
+        rules.append(resolve_rule(*r))
+    return rules
+
+
+def resolve_rule(name, test, t_arg, dst, action, a_arg, tag):
+    if not test:
+        test = "_default"
+    l_test = test.lower()
+    if l_test not in Tests.__dict__:
+        raise KeyError(f"no '{test}' in Tests, run with --more-help for full list")
+    test = Tests.__dict__[l_test](t_arg)
+
+    if not action:
+        action = "_default"
+    l_action = action.lower()
+    if l_action not in Actions.__dict__:
+        raise KeyError(f"no '{action}' in Actions, run with --more-help for full list")
+    action = Actions.__dict__[l_action](a_arg)
+
+    return (name, test, dst, action, tag)
+
+
+def x_parse_rules(l, aliases=None):
     "Parse a list of rule strings into rules suitable for statemachine.add"
     rules = []
     for s in l:
         parts = split_rule(s)
 
-        if aliases and len(parts) <= 3:
+        if aliases and len(parts) <= 3:  # FIXME: require $-prefix for alias lookups, give better error if unresolved
             # Very short rule may be an alias reference
             parts += [None,] * 3
-            if parts[1] in aliases:
-                r = [parts[0], *aliases[parts[1]]]
+            expansion = aliases.get(parts[1], None)
+            if expansion is not None:
+                r = [parts[0], *expansion]
                 if parts[2]:
                     # Override the tag if one was specified
                     r[-1] = parts[2]
@@ -367,7 +461,7 @@ def rules_from_file(rules_file):
         # lines = list(lines); print("\n".join(lines), end="")  # join "spends" the generator, convert to list first so it can be iterated again
         for l in lines:
             categorizer.input(l)
-
+    # print(f"Named: {named_lines}\nAdd:{add_lines}")  # BJH: debug
     return (named_lines, add_lines)
 
 

--- a/sled.md
+++ b/sled.md
@@ -19,16 +19,26 @@ Rules with no starting state will be added to all states, but are evaluated afte
 
 If an input does not match any rule for the current state, an exception is raised with a short trace of recent transitions; the depth of this trace can be set or additional tracing can be enabled with `-t/--trace`.
 
-Named rules can be defined with `-r/--named-rules` and start with a (non-whitespace) delimiter character of our choice follwed by 7 fields:
+Rules can be defined with `-r/--named-rules` and start with a (non-whitespace) delimiter character of our choice follwed by 7 fields:
 
     :name:test:arg:dst:action:arg:tag
 
-Rules are added to states in the underlying statemachine with `-a/--add-rules`, and may be either named or anonymous:
+Named rules can use previously defined named rule fragments; for example, a complex regular expression can be defined once and used elsewhere:
 
-    :state:name:tag
+    :CommentRE:(^|\s+)#($|[^#].*$)
+    :DropComments:S:CommentRE::S::
+
+Rules are added to states in the underlying statemachine with `-a/--add-rules`:
+
     :state:test:arg:dst:action:arg:tag
 
-For convenience, unnecessary fields may be omitted from the end in all cases, 'test' and 'action' commands are not case-sensitive, and named rules will be automatically tagged.
+For convenience, unnecessary fields may be omitted from the end in all cases, and 'test' and 'action' commands are not case-sensitive.  Rules with no 'state' specified are implicitly added to all states, but evaluated after any explicit rules; rules with no 'dst' remain in the same state ("self-transition")
+
+Rules can use previously defined rule fragments; if the rule is completely defined by a named rule, like the following, it will be auto-tagged with that name:
+
+    :state:name
+
+Use `--print-rules` to see the final parsed rules.  Note that named rules do not get automatically added to the parser; the 'Rules' list are the ones that define the parser.  They are added to their states in order, and earlier rules have precedence over later ones.
 
 In addtion to the general options and help that can be printed with `-h/--help`, available tests and actions are documented in `--more-help` and text styling is shown in `--style-help`.
 
@@ -41,6 +51,7 @@ In addtion to the general options and help that can be printed with `-h/--help`,
 A detailed example
 ------------------
 This example will use the `status.txt` file, a sanitized version of the output from a team status chatbot.  Throughout the example, we'll use the `:` delimiter as a convention, but each rule can be defined with any non-whitespace character that doesn't otherwise appear in the rule.
+
 
 ### Pass lines between delimiters
 
@@ -84,6 +95,7 @@ I didn't hear from @qed, @foo, @bar, @qux! Keep up your good work team!
 
 This could also be done with anonymous rules, as each rule was only added in one place in this example; named rules do have the advantage of automatic tagging to make trace output easier to understand, however.
 
+
 ### Tracing
 
 Statemachines are powerful and fascinating - and can be hard to debug if we can't see what they're doing sometimes.
@@ -110,6 +122,7 @@ T>          ==> '@bholt'
 ```
 
 Note the very last line above has no prefix, it is the parser's normal output.
+
 
 ### Unrecognized input
 

--- a/sled.md
+++ b/sled.md
@@ -25,8 +25,8 @@ Rules can be defined with `-r/--named-rules` and start with a (non-whitespace) d
 
 Named rules can use previously defined named rule fragments; for example, a complex regular expression can be defined once and used elsewhere:
 
-    :CommentRE:(^|\s+)#($|[^#].*$)
-    :DropComments:S:CommentRE::S::
+    `:CommentRE:(^|\s+)#($|[^#].*$)`
+    `:DropComments:S:CommentRE::S::`
 
 Rules are added to states in the underlying statemachine with `-a/--add-rules`:
 

--- a/sled.md
+++ b/sled.md
@@ -204,23 +204,24 @@ To Do
 - "reject" action?  cease parsing and exit non-zero, but don't throw
 
 - named tests & actions?
-    - or maybe general substitution macros?
-        - NO: will this be weird different delimiters? - nah, just parse the macro with its delimiter, then expand it in the parsed rule list with its already-split fields
-        - just like named rules: delim-name-delim-field...
-            - should named rules just be an instance of this? what to do about auto-tagging?
-        - multiple expansion? - powerful but fraught with peril ...but _powerful_
-            - ...but _perilous_ - what safeguards can be put in place?
-            - Expansion depth limit
-            - Expand only based on previously-defined expansions - expansions with undefined names are discarded?
-                - need verbose logging to see cases of this for debugging? or just use --print-args and see that things got lost?  or they get squirreled away and the ones that never get expanded are printed separately? - yeah, that one
-            - need a way to specify "expand this" - $name, $$junk to escape?  - have to apply escape at rule-add time
-            - expansions only apply in the named-rule parsing, all expanding should be done by the add-rules phase
-        - how to handle overriding named rules on the command-line - may want to override fundamental aliases like a test regex _or_ override "later" rules that use test regex defined in the file
+    - DONE: or maybe general substitution macros?
+        - NO: will this be weird with different delimiters? - nah, just parse the macro with its delimiter, then expand it in the parsed rule list with its already-split fields
+        - DONE: just like named rules: delim-name-delim-field...
+            - YES: should named rules just be an instance of this? DONE: what to do about auto-tagging?
+        - DONE: multiple expansion? - powerful but fraught with peril ...but _powerful_
+            - DONEish: ...but _perilous_ - what safeguards can be put in place?
+            - NO: Expansion depth limit - not needed
+            - DONE: Expand only based on previously-defined expansions - expansions with undefined names are discarded?
+                - NO: need verbose logging to see cases of this for debugging? - just use --print-args and see that things didn't expand; de-cloak print-args
+            - NO: need a way to specify "expand this" - $name, $$junk to escape?  - NO:have to apply escape at rule-add time - just like delimiters, define your own convention
+            - NO: expansions only apply in the named-rule parsing, all expanding should be done by the add-rules phase - they are a generalization of named rules, there's no real difference
+        - DONE: how to handle overriding named rules on the command-line - may want to override fundamental aliases like a test regex _or_ override "later" rules that use test regex defined in the file
             - parse command-line named rules once building a dictionary of any that don't depend on things not-yet-defined
             - parse file rules treating existing dictionary as canon, _not_ overriding anything already defined
             - parse command-line rules _again_ using expansions from existing dictionary, but _override_ existing dictionary items - rules that were defined in the first phase should override to themselves, rules that couldn't be expanded the first time around should now expand and override the file version
             - track rules whose definition failed due to missing expansions, minus ones that were eventually defined, print in print-args; if non-empty, maybe print warning?
             - _phew!_
+
 - good way to allow multiple actions to apply to a line
     - could allow one to just keep piling them on?
 

--- a/sled.md
+++ b/sled.md
@@ -203,25 +203,6 @@ To Do
 - End action?  cease parsing but exit normally (can fake it with an end state and drop-all rule)  Or could be "accept"
 - "reject" action?  cease parsing and exit non-zero, but don't throw
 
-- named tests & actions?
-    - DONE: or maybe general substitution macros?
-        - NO: will this be weird with different delimiters? - nah, just parse the macro with its delimiter, then expand it in the parsed rule list with its already-split fields
-        - DONE: just like named rules: delim-name-delim-field...
-            - YES: should named rules just be an instance of this? DONE: what to do about auto-tagging?
-        - DONE: multiple expansion? - powerful but fraught with peril ...but _powerful_
-            - DONEish: ...but _perilous_ - what safeguards can be put in place?
-            - NO: Expansion depth limit - not needed
-            - DONE: Expand only based on previously-defined expansions - expansions with undefined names are discarded?
-                - NO: need verbose logging to see cases of this for debugging? - just use --print-args and see that things didn't expand; de-cloak print-args
-            - NO: need a way to specify "expand this" - $name, $$junk to escape?  - NO:have to apply escape at rule-add time - just like delimiters, define your own convention
-            - NO: expansions only apply in the named-rule parsing, all expanding should be done by the add-rules phase - they are a generalization of named rules, there's no real difference
-        - DONE: how to handle overriding named rules on the command-line - may want to override fundamental aliases like a test regex _or_ override "later" rules that use test regex defined in the file
-            - parse command-line named rules once building a dictionary of any that don't depend on things not-yet-defined
-            - parse file rules treating existing dictionary as canon, _not_ overriding anything already defined
-            - parse command-line rules _again_ using expansions from existing dictionary, but _override_ existing dictionary items - rules that were defined in the first phase should override to themselves, rules that couldn't be expanded the first time around should now expand and override the file version
-            - track rules whose definition failed due to missing expansions, minus ones that were eventually defined, print in print-args; if non-empty, maybe print warning?
-            - _phew!_
-
 - good way to allow multiple actions to apply to a line
     - could allow one to just keep piling them on?
 
@@ -274,5 +255,25 @@ To Do
 
 - DONE: case-insensitive match and search actions
     - PUNT: any other flags?
+
+- DONE: named tests & actions?
+    - DONE: or maybe general substitution macros?
+        - NO: will this be weird with different delimiters? - nah, just parse the macro with its delimiter, then expand it in the parsed rule list with its already-split fields
+        - DONE: just like named rules: delim-name-delim-field...
+            - YES: should named rules just be an instance of this?  what to do about auto-tagging?
+            - DONE: only auto-tag :state:rule; too easy to for :state:$NamedTest:dst to be confused with the old :state:name:tag and it would get horibly mangled
+        - DONE: multiple expansion? - powerful but fraught with peril ...but _powerful_
+            - DONEish: ...but _perilous_ - what safeguards can be put in place?
+            - NO: Expansion depth limit - not needed
+            - DONE: Expand only based on previously-defined expansions - expansions with undefined names are discarded?
+                - NO: need verbose logging to see cases of this for debugging? - just use --print-args and see that things didn't expand; de-cloak print-args
+            - NO: need a way to specify "expand this" - $name, $$junk to escape?  - NO:have to apply escape at rule-add time - just like delimiters, define your own convention
+            - NO: expansions only apply in the named-rule parsing, all expanding should be done by the add-rules phase - they are a generalization of named rules, there's no real difference
+        - DONE: how to handle overriding named rules on the command-line - may want to override fundamental aliases like a test regex _or_ override "later" rules that use test regex defined in the file
+            - parse command-line named rules once building a dictionary of any that don't depend on things not-yet-defined
+            - parse file rules treating existing dictionary as canon, _not_ overriding anything already defined
+            - parse command-line rules _again_ using expansions from existing dictionary, but _override_ existing dictionary items - rules that were defined in the first phase should override to themselves, rules that couldn't be expanded the first time around should now expand and override the file version
+            - track rules whose definition failed due to missing expansions, minus ones that were eventually defined, print in print-args; if non-empty, maybe print warning?
+            - _phew!_
 
 ---

--- a/statusparser.sled
+++ b/statusparser.sled
@@ -19,26 +19,26 @@ Named Rules:
 # These lines would still be parsed, so #-comments are required
 
 Add Rules  # Lenient about the trailing ':'
-    :start:startYesterday
-    :start:startToday
-    :start:DropAll
+    :start:$startYesterday
+    :start:$startToday
+    :start:$DropAll
 
   addrules:  # Lenient about case and whitespace, too
-    :yesterday:startToday
+    :yesterday:$startToday
     :yesterday:M:@bholt:myYesterday
-    :yesterday:DropAll
+    :yesterday:$DropAll
 
-    :myYesterday:startToday
+    :myYesterday:$startToday
     :myYesterday:M:^@\w+$:yesterday
-    :myYesterday:myStatus
+    :myYesterday:$myStatus
 
-    :today:startHowFar
+    :today:$startHowFar
     :today:M:@bholt:myToday
-    :today:DropAll
+    :today:$DropAll
 
-    :myToday:startHowFar
+    :myToday:$startHowFar
     :myToday:M:^@\w+$:today
-    :myToday:myStatus
+    :myToday:$myStatus
 End Rules
 
 -----

--- a/statusparser.sled
+++ b/statusparser.sled
@@ -14,12 +14,12 @@ All this content is ignored without being explicitly marked as comments.
 
 Named Rules:
     # These are questions that define the status-bot's sections:
-    /startYesterday/L/1. What did you do yesterday?/yesterday/L/_Yesterday:_  # Use '/' since the action string has ':'
-    /startToday/L/2. What do you commit to today?/today/L/_Today:_
-    :startHowFar:L:3. How far along are you? Do you think you'll finish soon?:start
+    /$startYesterday/L/1. What did you do yesterday?/yesterday/L/_Yesterday:_  # Use '/' since the action string has ':'
+    /$startToday/L/2. What do you commit to today?/today/L/_Today:_
+    :$startHowFar:L:3. How far along are you? Do you think you'll finish soon?:start
 
     # My status lines should be 'F'ormatted with a block-quote ('> ') prefix
-    :myStatus:T:::F:> {i}
+    :$myStatus:T:::F:> {i}
 
 # Don't need to explicitly end a rule block if it's immediately followed by another
 # These lines would still be parsed, so #-comments are required
@@ -66,6 +66,6 @@ Define some basic standbys down here out of the way; named rules are still avail
 Anything between rules blocks is still ignored.
 
 Named Rules:  # Rules defined late in the file are still usable
-    :PassAll:T:::I
-    :DropAll:T
+    :$PassAll:T:::I
+    :$DropAll:T
 # End Rules is only required if there is additional content before the end of the file

--- a/statusparser.sled
+++ b/statusparser.sled
@@ -65,7 +65,7 @@ Define some basic standbys down here out of the way; named rules are still avail
 
 Anything between rules blocks is still ignored.
 
-Named Rules:  # Rules defined late in the file are still usable
+Named Rules:  # Rules defined late in the file are still usable at add-rules time
     :$PassAll:T:::I
     :$DropAll:T
 # End Rules is only required if there is additional content before the end of the file

--- a/statusparser.sled
+++ b/statusparser.sled
@@ -1,6 +1,12 @@
+#!/usr/bin/env sled -f
+
 Parse only my status out of a team standup message.  Clone of `statusparser` using sled rules; compare both implentations, but keep in mind that this one is a bit messy to demonstrate how `sled` parses a rules file.
 
-Run like this:
+Run like this if sled is in the PATH:
+
+> ./statusparser.sled < status.txt
+
+or:
 
 > cat status.txt | ./sled -f statusparser.sled
 


### PR DESCRIPTION
Allow named rules to specify "rule fragments" that can be referenced in other named or added rules.

Basic usage should be largely unaffected, but THIS INCLUDES SOME BREAKING CHANGES:
- Added rules of the form `:state:name:tag` will no longer tag the rule since that is too easy to confuse with `:state:NamedTest:dst`; only `:state:name` will be auto-tagged
- Any field can now expand to a named rule fragment if it matches a rule name, this may add any number of fields and break things